### PR TITLE
feat(icons): css file with embed font version added

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -81,6 +81,13 @@ module.exports = function (grunt) {
                 dest: PATH_BUILD_ICONS
             }
         },
+        embedFonts: {
+            all: {
+                files: {
+                    'dist/styles/mc-icons-embed.css': ['dist/styles/mc-icons.css']
+                }
+            }
+        },
         webfont: {
             run: {
                 src: PATH_BUILD_ICONS + '/*.svg',
@@ -154,9 +161,10 @@ module.exports = function (grunt) {
 
     grunt.loadNpmTasks('grunt-sketch');
     grunt.loadNpmTasks('grunt-webfont');
+    grunt.loadNpmTasks('grunt-embed-fonts');
     grunt.loadNpmTasks('grunt-rename-util');
     grunt.loadNpmTasks('grunt-text-replace');
 
-    grunt.registerTask('publish', ['sketch_export:run', 'shell:svgfromsubfolder', 'shell:svgrename', 'replace:remove_mask', 'webfont:run', 'rename:main', 'shell:publish']);
-    grunt.registerTask('default', ['sketch_export:run', 'shell:svgfromsubfolder', 'shell:svgrename', 'replace:remove_mask', 'webfont:run', 'rename:main',]);
+    grunt.registerTask('publish', ['sketch_export:run', 'shell:svgfromsubfolder', 'shell:svgrename', 'replace:remove_mask', 'webfont:run', 'rename:main', 'embedFonts', 'shell:publish']);
+    grunt.registerTask('default', ['sketch_export:run', 'shell:svgfromsubfolder', 'shell:svgrename', 'replace:remove_mask', 'webfont:run', 'rename:main', 'embedFonts']);
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,8 +1,4 @@
-//import {requires} from "grunt";
-
 var FONT_VERSION = '1.9.5';
-
-//var path = requires('path');
 
 var CODEPOINTS = {
     'angle-down-L_16'           : 0xF101,
@@ -62,10 +58,6 @@ const PATH_BUILD_ICONS = './build/icons',
 
 const SKETCH_FILE_DEF = 'mosaic-icons-iconset.sketch';
 
-//const ABSOLUT_PATH = path.resolve();
-
-//console.log(ABSOLUT_PATH);
-
 
 module.exports = function (grunt) {
 
@@ -119,7 +111,7 @@ module.exports = function (grunt) {
         shell: {
             publish: {command: 'npm publish'},
             svgfromsubfolder : {
-                command: 'find ' + PATH_BUILD_ICONS + ' -mindepth 2 -type f -print -exec mv {} ' + PATH_BUILD_ICONS + '/ \\;'
+                command: 'find ' + PATH_BUILD_ICONS + ' -mindepth 2 -type f -print -exec mv {} ' + PATH_BUILD_ICONS + '/ \\;'  
               },
             svgrename: {
                 command: 'cd build/icons && for f in *.svg; do mv "$f" "${f#mc-}"; done'

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,4 +1,8 @@
+//import {requires} from "grunt";
+
 var FONT_VERSION = '1.9.5';
+
+//var path = requires('path');
 
 var CODEPOINTS = {
     'angle-down-L_16'           : 0xF101,
@@ -58,6 +62,10 @@ const PATH_BUILD_ICONS = './build/icons',
 
 const SKETCH_FILE_DEF = 'mosaic-icons-iconset.sketch';
 
+//const ABSOLUT_PATH = path.resolve();
+
+//console.log(ABSOLUT_PATH);
+
 
 module.exports = function (grunt) {
 
@@ -111,7 +119,7 @@ module.exports = function (grunt) {
         shell: {
             publish: {command: 'npm publish'},
             svgfromsubfolder : {
-                command: 'find ' + PATH_BUILD_ICONS + ' -mindepth 2 -type f -print -exec mv {} ' + PATH_BUILD_ICONS + '/ \\;'  
+                command: 'find ' + PATH_BUILD_ICONS + ' -mindepth 2 -type f -print -exec mv {} ' + PATH_BUILD_ICONS + '/ \\;'
               },
             svgrename: {
                 command: 'cd build/icons && for f in *.svg; do mv "$f" "${f#mc-}"; done'

--- a/package-lock.json
+++ b/package-lock.json
@@ -708,6 +708,23 @@
                 }
             }
         },
+        "grunt-embed-fonts": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/grunt-embed-fonts/-/grunt-embed-fonts-1.0.2.tgz",
+            "integrity": "sha512-Y2FIE54QJXBfmPtG3nKnQz4adw4+1qBGRhBambaKIyyYa7mFfV2xS0g+cEvGsPw+ntfPjictDBduLefPPwoCYQ==",
+            "dev": true,
+            "requires": {
+                "path-is-absolute": "^2.0.0"
+            },
+            "dependencies": {
+                "path-is-absolute": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-2.0.0.tgz",
+                    "integrity": "sha512-ajROpjq1SLxJZsgSVCcVIt+ZebVH+PwJtPnVESjfg6JKwJGwAgHRC3zIcjvI0LnecjIHCJhtfNZ/Y/RregqyXg==",
+                    "dev": true
+                }
+            }
+        },
         "grunt-known-options": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/grunt-known-options/-/grunt-known-options-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "homepage": "https://github.com/positive-js/mosaic-icons#readme",
     "devDependencies": {
         "grunt": "^1.0.4",
+        "grunt-embed-fonts": "^1.0.2",
         "grunt-rename-util": "^1.0.0",
         "grunt-shell": "^3.0.1",
         "grunt-sketch": "^1.0.5",


### PR DESCRIPTION
.css file with embed font version added for stackblitz support. File is generating with grunt-embed-fonts task. Base css, scss and less files remains unchanged.